### PR TITLE
feat: export useTheme and useUndoManager from the public entry

### DIFF
--- a/src/core/main/index.ts
+++ b/src/core/main/index.ts
@@ -65,5 +65,7 @@ export { useReplaceBlock } from "~/hooks/use-replace-block";
 export { useSavePage } from "~/hooks/use-save-page";
 export { useSelectedBlock } from "~/hooks/use-selected-blockIds";
 export { useStreamMultipleBlocksProps } from "~/hooks/use-update-blocks-props";
+export { useTheme, useThemeOptions } from "~/hooks/use-theme";
+export { useUndoManager, undoManager } from "~/hooks/history/use-undo-manager";
 export * from "~/runtime/client";
 export type { ChaiTheme } from "~/types/chaibuilder-editor-props";


### PR DESCRIPTION
### What

Adds two export lines to `src/core/main/index.ts`:

```ts
export { useTheme, useThemeOptions } from "~/hooks/use-theme";
export { useUndoManager, undoManager } from "~/hooks/history/use-undo-manager";
```

Additive only — no behaviour changes, nothing existing touched.

### Why

Both hooks already exist and are used internally; they are just missing from the public entry. `src/hooks/index.ts` lists them, but that file points at `~/core/hooks/...`, which no longer exists, so nothing consumes it.

I hit two walls building an editor on the SDK that I could not get past from outside the package.

**1. A host cannot repaint the canvas after the theme panel has been used.**

`useTheme` computes:

```ts
{ ...defaultThemeValues, ...(!isEmpty(theme) && theme), ...(!isEmpty(chaiTheme) && chaiTheme) }
```

`chaiThemeValuesAtom` is spread last, and the built-in theme panel writes the whole merged theme into it on its first edit. From that moment the host's `theme` prop can never affect the canvas again. The atom is module-scope with no jotai `Provider`, so a React remount does not clear it either — only a full page load does.

My app lets an owner change the site's look as a draft and then discard it. The only way to make the canvas show the restored theme was `window.location.reload()`, which also throws away the user's block undo history for a change that never touched a block. With `useTheme` exported, `setChaiTheme({})` empties the override (`isEmpty({})` makes that spread a no-op) and the prop wins again — same repaint, no page load.

**2. A host cannot drive undo/redo.**

The `UndoManager` instance is module-private and `ChaiUndoRedo` is the only undo-related symbol exported. The keyboard shortcut dialog advertises Redo as `⌘⇧Z`, but the binding is `"ctrl+y,meta+y"` and `react-hotkeys-hook@5` requires an exact shift match, so that chord does nothing. Without an API the only way to implement it was to find the Redo button in the DOM by its `aria-label` and click it, which is fragile in an obvious way.

I have exported the **singleton alongside the hook** deliberately, and it is worth flagging: `useUndoManager()` reads `builderSaveStateAtom`, so calling it subscribes the caller to save-state changes. In my app, calling it in the component that owns the editor caused a re-render of the whole editor on every autosave transition. A keyboard shortcut only needs `undoManager.redo()`, with no subscription — hence both.

### Testing

`pnpm test` on this branch: 53 files, 545 passed, 1 skipped. `pnpm build` reproduces normally.

Happy to split this into two PRs, drop the `undoManager` singleton, or move the exports elsewhere if you would rather they live behind a different entry — the two hooks are what matter.